### PR TITLE
added results SNHC 2025. Fixed typo in SNHC 2024

### DIFF
--- a/data/2024-scottish-national.yaml
+++ b/data/2024-scottish-national.yaml
@@ -3,7 +3,7 @@ year: 2024
 date: 27-01-2024
 abbr_name: SNHC
 full_name: Scottish National Homebrew Competition
-location: Edinburth
+location: Edinburgh
 guidelines: BJCP 2021
 winners:
   - name: Ian Cosier

--- a/data/2025-scottish-national.yaml
+++ b/data/2025-scottish-national.yaml
@@ -1,0 +1,34 @@
+---
+year: 2025
+date: 25-01-2025
+abbr_name: SNHC
+full_name: Scottish National Homebrew Competition
+location: Edinburgh
+guidelines: BJCP 2021
+winners:
+  - name: Phill Turner
+    flight:
+      silver:
+        - name: Warrior Queen
+          style: 11A
+  - name: Ian Cosier
+    flight:
+      silver:
+        - name: Green Run
+          style: 12C
+          asst_brewer: Marie Coppet & Fede Garcia
+  - name: Arthur Olcot
+    flight:
+      HM:
+        - name: Bigger Hills And Hangovers
+          style: 14B
+  - name: Lucas Stolarczyk
+    flight:
+      bronze:
+        - name: The Midnight Snack
+          style: 19C
+  - name: Mark Hopkins
+    flight:
+      gold:
+        - name: Pineapple Pony
+          style: 18B


### PR DESCRIPTION
- added results for Scottish National 2025
- fixed typo in Scottish National 2024